### PR TITLE
Added Region ID Enum

### DIFF
--- a/src/uk/ac/cam/ia/group14/util/RegionID.java
+++ b/src/uk/ac/cam/ia/group14/util/RegionID.java
@@ -1,0 +1,5 @@
+package uk.ac.cam.ia.group14.util;
+
+public enum RegionID {
+    CAIRNGORMS, GRAMPIANS, PENNINES, MOURNES, SNOWDONIA, BREACONS;
+}


### PR DESCRIPTION
Created enum containing 6 major mountain ranges across the 4 constituent parts of Great Britain.